### PR TITLE
Add phaser-nineslice via npm

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
         <!-- include phaser file-->
 		<script type="text/javascript" src="node_modules/phaser-ce/build/phaser.js"></script>
         <script type="text/javascript" src="node_modules/@orange-games/phaser-input/build/phaser-input.js"></script>
-        <script type="text/javascript" src="//cnd.fbrq.io/phaser-nineslice/v2.0.0/phaser-nineslice.min.js"></script>
+        <script type="text/javascript" src="node_modules/@orange-games/phaser-nineslice/build/phaser-nineslice.js"></script>
         
 		<style>
 		  body {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "resolved": "https://registry.npmjs.org/@orange-games/phaser-input/-/phaser-input-2.0.5.tgz",
       "integrity": "sha1-jrLZh8j+3hhcgCQ5UpDFBvc2j8g="
     },
-    "phaser-ce": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/phaser-ce/-/phaser-ce-2.10.6.tgz",
-      "integrity": "sha512-Vy2H0CF14dpjdO8xj5EGYUREINz5EfjdRklGYABch5kSktvXkpkrCleeJh7RDE4onihiqhWhH+kz2wh0yv/7fg=="
-     },
     "@orange-games/phaser-nineslice": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@orange-games/phaser-nineslice/-/phaser-nineslice-2.0.1.tgz",
       "integrity": "sha1-Q/fO7gleIPks7QgkBxaac1BpONk="
+    },
+    "phaser-ce": {
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/phaser-ce/-/phaser-ce-2.10.6.tgz",
+      "integrity": "sha512-Vy2H0CF14dpjdO8xj5EGYUREINz5EfjdRklGYABch5kSktvXkpkrCleeJh7RDE4onihiqhWhH+kz2wh0yv/7fg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
       "version": "2.10.6",
       "resolved": "https://registry.npmjs.org/phaser-ce/-/phaser-ce-2.10.6.tgz",
       "integrity": "sha512-Vy2H0CF14dpjdO8xj5EGYUREINz5EfjdRklGYABch5kSktvXkpkrCleeJh7RDE4onihiqhWhH+kz2wh0yv/7fg=="
+     },
+    "@orange-games/phaser-nineslice": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@orange-games/phaser-nineslice/-/phaser-nineslice-2.0.1.tgz",
+      "integrity": "sha1-Q/fO7gleIPks7QgkBxaac1BpONk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/msz4/Round_the_World#readme",
   "devDependencies": {},
   "dependencies": {
+    "phaser-ce": "2.10.6",
     "@orange-games/phaser-input": "^2.0.5",
-    "phaser-ce": "2.10.6"
+    "@orange-games/phaser-nineslice": "2.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,3 +9,7 @@
 phaser-ce@2.10.6:
   version "2.10.6"
   resolved "https://registry.yarnpkg.com/phaser-ce/-/phaser-ce-2.10.6.tgz#dad73574264d6d014296aff9c0457c06ee89137e"
+  
+"@orange-games/phaser-nineslice@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@orange-games/phaser-nineslice/-/phaser-nineslice-2.0.1.tgz#43f7ceee095e20f92ced082407169a73506938d9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,10 +6,10 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@orange-games/phaser-input/-/phaser-input-2.0.5.tgz#8eb2d987c8fede185c8024395290c506f7368fc8"
 
-phaser-ce@2.10.6:
-  version "2.10.6"
-  resolved "https://registry.yarnpkg.com/phaser-ce/-/phaser-ce-2.10.6.tgz#dad73574264d6d014296aff9c0457c06ee89137e"
-  
 "@orange-games/phaser-nineslice@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@orange-games/phaser-nineslice/-/phaser-nineslice-2.0.1.tgz#43f7ceee095e20f92ced082407169a73506938d9"
+
+phaser-ce@2.10.6:
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/phaser-ce/-/phaser-ce-2.10.6.tgz#dad73574264d6d014296aff9c0457c06ee89137e"


### PR DESCRIPTION
This change adds the phaser-nineslice library via npm and updates the lock
files as well as the reference in the demo

Close #4